### PR TITLE
Now works with Node 0.6.4

### DIFF
--- a/lib/minecraft.js
+++ b/lib/minecraft.js
@@ -12,7 +12,7 @@ var Colors = require('./colors.json');
 function Minecraft (host, port, callback) {
     var self = this;
 
-    this.connection = net.connect({port: port, host: host}, function () {
+    this.connection = net.connect(port, host, function () {
         // When a new `Minecraft` is created, it connects to the port and host given, and preforms the callback, if it exists, once connected.
         console.log('Connected to server!');
         self.chat('Hello from Node.js! Commanding from '  + os.hostname());


### PR DESCRIPTION
Since the version of Node shipped on Raspbian's distribution is 0.6.19, according to http://ricochen.wordpress.com/2012/07/24/install-node-js-on-raspberry-pi-in-two-simple-steps/ , it might be worthwhile to make the API work on older versions of NodeJS.

It's also important for me because I test on a Ubuntu 10.04 machine, which ships with Node 0.6.4.
